### PR TITLE
luaposix install problem

### DIFF
--- a/cuda-7.5/Dockerfile
+++ b/cuda-7.5/Dockerfile
@@ -64,6 +64,10 @@ RUN luarocks install unsup
 # Install HTTP client
 RUN luarocks install httpclient
 
+
+ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs \
+	DYLD_LIBRARY_PATH=/root/torch/install/lib:/root/torch/install/lib:/root/torch/install/lib
+
 # Install Lua POSIX bindings
 RUN luarocks install luaposix
 


### PR DESCRIPTION
fixed problem where there is no *LIBRARY_PATH set prior to script runing, luaposix (and others) do not install  (yes, this WAS easy)
